### PR TITLE
Add support for wrapping PostgreSQL JSON queries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
   - 5.5
   - 5.6
   - hhvm

--- a/src/Query/Grammars/PostgresGrammar.php
+++ b/src/Query/Grammars/PostgresGrammar.php
@@ -1,22 +1,76 @@
-<?php namespace Bosnadev\Database\Query\Grammars;
+<?php
+namespace Bosnadev\Database\Query\Grammars;
+
+use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\Grammars\PostgresGrammar as LaravelPostgresGrammar;
 
 /**
  * Class PostgresGrammar
+ *
  * @package Bosnadev\Database\Query\Grammars
  */
-class PostgresGrammar extends \Illuminate\Database\Query\Grammars\PostgresGrammar {
+class PostgresGrammar extends LaravelPostgresGrammar
+{
+    /**
+     * @var array
+     */
+    protected $jsonOperators = [
+        '->',
+        '->>',
+        '#>',
+        '#>>',
+    ];
 
     /**
      * @param string $value
+     *
      * @return string
      */
     protected function wrapValue($value)
     {
-        // If quering hstore
-        if( preg_match('/\[(.*?)\]/', $value, $match) ) {
-            return (string) str_replace(array( '[', ']' ), '', $match[1]);
+        if ($value === '*') {
+            return $value;
         }
 
-        return parent::wrapValue( $value );
+        // If querying hstore
+        if (preg_match('/\[(.*?)\]/', $value, $match)) {
+            return (string)str_replace(array('[', ']'), '', $match[1]);
+        }
+
+        // If querying json column
+        foreach ($this->jsonOperators as $operator) {
+            if (stripos($value, $operator)) {
+                list($value, $key) = explode($operator, $value, 2);
+                return parent::wrapValue($value) . $operator . $key;
+            }
+        }
+
+        return parent::wrapValue($value);
     }
-} 
+
+    /**
+     * Compile a "where null" clause.
+     *
+     * @param  Builder $query
+     * @param  array   $where
+     *
+     * @return string
+     */
+    protected function whereNull(Builder $query, $where)
+    {
+        return '(' . $this->wrap($where['column']) . ') is null';
+    }
+
+    /**
+     * Compile a "where not null" clause.
+     *
+     * @param  Builder $query
+     * @param  array   $where
+     *
+     * @return string
+     */
+    protected function whereNotNull(Builder $query, $where)
+    {
+        return '(' . $this->wrap($where['column']) . ') is not null';
+    }
+}

--- a/tests/Query/Grammars/PostgresGrammarTest.php
+++ b/tests/Query/Grammars/PostgresGrammarTest.php
@@ -2,12 +2,47 @@
 
 use BaseTestCase;
 use Bosnadev\Database\Query\Grammars\PostgresGrammar;
+use Illuminate\Database\Query\Builder;
 use Mockery;
 
-class PostgresGrammarTest extends BaseTestCase {
-	public function testWrapValue() {
-		$grammar = Mockery::mock( PostgresGrammar::class )->makePartial();
+class PostgresGrammarTest extends BaseTestCase
+{
+    public function testHstoreWrapValue()
+    {
+        $grammar = Mockery::mock(PostgresGrammar::class)->makePartial();
 
-		$this->assertEquals( 'a => b', $grammar->wrapValue( '[a => b]' ) );
-	}
+        $this->assertEquals('a => b', $grammar->wrapValue('[a => b]'));
+    }
+
+    public function testJsonWrapValue()
+    {
+        $grammar = Mockery::mock(PostgresGrammar::class)->makePartial();
+
+        $this->assertEquals('"a"->\'b\'', $grammar->wrapValue("a->'b'"));
+        $this->assertEquals('"a"->>\'b\'', $grammar->wrapValue("a->>'b'"));
+        $this->assertEquals('"a"#>\'b\'', $grammar->wrapValue("a#>'b'"));
+        $this->assertEquals('"a"#>>\'b\'', $grammar->wrapValue("a#>>'b'"));
+    }
+
+    public function testWhereNotNull()
+    {
+        $grammar = Mockery::mock(PostgresGrammar::class)->makePartial();
+        $builder = Mockery::mock(Builder::class);
+        $where = [
+            'column' => "a->>'b'"
+        ];
+
+        $this->assertEquals('("a"->>\'b\') is not null', $grammar->whereNotNull($builder, $where));
+    }
+
+    public function testWhereNull()
+    {
+        $grammar = Mockery::mock(PostgresGrammar::class)->makePartial();
+        $builder = Mockery::mock(Builder::class);
+        $where = [
+            'column' => "a->>'b'"
+        ];
+
+        $this->assertEquals('("a"->>\'b\') is null', $grammar->whereNull($builder, $where));
+    }
 }


### PR DESCRIPTION
I'm currently using https://github.com/darrylkuhn/dialect along side this package to better support the JSON columns in PostgreSQL, however, relationships on an external model to a model that has a JSON column fail because of incorrect wrapping of the JSON operators, e.g.

```
Undefined column: 7 ERROR:  column jobs.data->>'unit_id' does not exist
```
```sql
select * from "jobs" where "jobs"."data->>'unit_id'" = 2657 and "jobs"."data->>'unit_id'" is not null
```

The fix for that is in the wrapValue method and simply extends what's already there for the hstore wrapping.

Once that was fixed, there's another error when checking `is null` and `is not null`

```
Undefined function: 7 ERROR:  operator does not exist: jsonb ->> boolean
```
```sql
select * from "jobs" where "jobs"."data"->>'unit_id' = 2657 and "jobs"."data"->>'unit_id' is not null
```

The fix for this is to wrap the column and key within brackets

```sql
select * from "jobs" where "jobs"."data"->>'unit_id' = 2657 and ("jobs"."data"->>'unit_id') is not null
```