### PR TITLE
Don't repeat what Laravel already does for the default values

### DIFF
--- a/src/Schema/Grammars/PostgresGrammar.php
+++ b/src/Schema/Grammars/PostgresGrammar.php
@@ -57,13 +57,9 @@ class PostgresGrammar extends \Illuminate\Database\Schema\Grammars\PostgresGramm
      */
     protected function getDefaultValue($value)
     {
-        if ($value instanceof Expression) return $value;
-
-        if (is_bool($value)) return "'".intval($value)."'";
-
         if( $this->isUuid( $value ) ) return strval($value);
 
-        return "'".strval($value)."'";
+        return parent::getDefaultValue($value);
     }
 
     /**


### PR DESCRIPTION
There is an issue with a missing import in the Postgres schema grammar causing `Expression`s that are passed in to be treated as strings (there should be a `use Illuminate\Database\Query\Expression;`).

Instead of adding the import though it's probably better to just let Laravel do whatever it normally does if it's not a UUID that's being passed in (just in case they add anything else).