### PR TITLE
Larave/Lumen 5.2 and PHP7 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 before_script:

--- a/src/Connectors/ConnectionFactory.php
+++ b/src/Connectors/ConnectionFactory.php
@@ -21,7 +21,7 @@ class ConnectionFactory extends \Illuminate\Database\Connectors\ConnectionFactor
      * @return PostgresConnection|MySqlConnection|SQLiteConnection|SqlServerConnection|mixed|object
      * @throws \InvalidArgumentException
      */
-    protected function createConnection($driver, PDO $connection, $database, $prefix = '', array $config = array())
+    protected function createConnection($driver, $connection, $database, $prefix = '', array $config = array())
     {
         if ($this->container->bound($key = "db.connection.{$driver}")) {
             return $this->container->make($key, array($connection, $database, $prefix, $config));

--- a/src/DatabaseServiceProvider.php
+++ b/src/DatabaseServiceProvider.php
@@ -19,14 +19,14 @@ class DatabaseServiceProvider extends \Illuminate\Database\DatabaseServiceProvid
         // The connection factory is used to create the actual connection instances on
         // the database. We will inject the factory into the manager so that it may
         // make the connections while they are actually needed and not of before.
-        $this->app->bindShared('db.factory', function ($app) {
+        $this->app->singleton('db.factory', function ($app) {
             return new ConnectionFactory($app);
         });
 
         // The database manager is used to resolve various connections, since multiple
         // connections might be managed. It also implements the connection resolver
         // interface which may be used by other components requiring connections.
-        $this->app->bindShared('db', function ($app) {
+        $this->app->singleton('db', function ($app) {
             return new DatabaseManager($app, $app['db.factory']);
         });
     }


### PR DESCRIPTION
Includes commits by EspadaV8 (in pr https://github.com/Bosnadev/Database/pull/19) making 5.2 compatible, I've added change to make method signature compatible with parent for `createConnection`, this is required for PHP7 compatibility