### PR TITLE
Make createConnection compatible with framework v5.2.7

### DIFF
--- a/src/Connectors/ConnectionFactory.php
+++ b/src/Connectors/ConnectionFactory.php
@@ -1,6 +1,5 @@
 <?php namespace Bosnadev\Database\Connectors;
 
-use PDO;
 use Illuminate\Database\MySqlConnection;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Database\SqlServerConnection;
@@ -14,14 +13,14 @@ class ConnectionFactory extends \Illuminate\Database\Connectors\ConnectionFactor
 {
     /**
      * @param string $driver
-     * @param PDO $connection
+     * @param $connection
      * @param string $database
      * @param string $prefix
      * @param array $config
      * @return PostgresConnection|MySqlConnection|SQLiteConnection|SqlServerConnection|mixed|object
      * @throws \InvalidArgumentException
      */
-    protected function createConnection($driver, PDO $connection, $database, $prefix = '', array $config = array())
+    protected function createConnection($driver, $connection, $database, $prefix = '', array $config = array())
     {
         if ($this->container->bound($key = "db.connection.{$driver}")) {
             return $this->container->make($key, array($connection, $database, $prefix, $config));


### PR DESCRIPTION
Framework v5.2.7 changes the logic to defer PDO creation, this means the `createConnection()` method accepts a simple `$connection` variable and not one type-hinted with `PDO`. So our method shouldn’t either otherwise we get a compatability error.