### PR TITLE
Added table inheritance - $table->inherits('name')

### DIFF
--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -7,6 +7,23 @@
 class Blueprint extends \Illuminate\Database\Schema\Blueprint
 {
     /**
+     * Inherited table name
+     * @var string
+     */
+    public $inherits;
+
+    /**
+     * Specify table inheritance.
+     *
+     * @param  string $table
+     * @return void
+     */
+    public function inherits($table)
+    {
+        $this->inherits = $table;
+    }
+
+    /**
      * Add the index commands fluently specified on columns.
      *
      * @return void

--- a/src/Schema/Grammars/PostgresGrammar.php
+++ b/src/Schema/Grammars/PostgresGrammar.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Fluent;
 use Bosnadev\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Blueprint as BaseBlueprint;
 
 /**
  * Class PostgresGrammar
@@ -159,5 +160,22 @@ class PostgresGrammar extends \Illuminate\Database\Schema\Grammars\PostgresGramm
         $columns = $this->columnize($command->columns);
 
         return sprintf('CREATE INDEX %s ON %s USING GIN(%s)', $command->index, $this->wrapTable($blueprint), $columns);
+    }
+
+    /**
+     * Compile create table query.
+     *
+     * @param  Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string
+     */
+    public function compileCreate(BaseBlueprint $blueprint, Fluent $command)
+    {
+        $sql = parent::compileCreate($blueprint, $command);
+
+        if (isset($blueprint->inherits)) {
+            $sql .= ' INHERITS ("'.$blueprint->inherits.'")';
+        }
+        return $sql;
     }
 }


### PR DESCRIPTION
Added postgresql table inheritance feature.

Using:
```
Schema::create('test', function ($table) {
    $table->string('name');
});

Schema::create('subtest', function ($table) {
    $table->string('text');
    $table->inherits('test');
});
```
Now table subtest inherited from test table and have both name and text fields.
