### PR TITLE
Add Tsvector Column Type to Blueprint

### DIFF
--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -298,4 +298,16 @@ class Blueprint extends \Illuminate\Database\Schema\Blueprint
     {
         return $this->addColumn('daterange', $column);
     }
+    
+    /**
+     * Create a new tsvector column on the table.
+     *
+     * @param $column
+     *
+     * @return \Illuminate\Support\Fluent
+     */
+    public function tsvector($column)
+    {
+        return $this->addColumn('tsvector', $column);
+    }
 }

--- a/src/Schema/Grammars/PostgresGrammar.php
+++ b/src/Schema/Grammars/PostgresGrammar.php
@@ -248,6 +248,18 @@ class PostgresGrammar extends \Illuminate\Database\Schema\Grammars\PostgresGramm
     {
         return "daterange";
     }
+    
+    /**
+     * Create the column definition for a Text Search Vector type.
+     *
+     * @param Fluent $column
+     *
+     * @return string
+     */
+    protected function typeTsvector(Fluent $column)
+    {
+        return "tsvector";
+    }
 
     /**
      * @param mixed $value

--- a/tests/Schema/Grammars/PostgresGrammarTest.php
+++ b/tests/Schema/Grammars/PostgresGrammarTest.php
@@ -144,6 +144,20 @@ class PostgresGrammarBaseTest extends BaseTestCase
         $this->assertContains('alter table', $statements[0]);
         $this->assertContains('add column "foo" daterange', $statements[0]);
     }
+    
+    public function testAddingTsvector()
+    {
+        $blueprint = new Blueprint('test');
+        $blueprint->tsvector('foo');
+        $statements = $blueprint->toSql(
+            $this->getConnection(),
+            $this->getGrammar()
+        );
+        
+        $this->assertEquals(1, count($statements));
+        $this->assertContains('alter table', $statements[0]);
+        $this->assertContains('add column "foo" tsvector', $statements[0]);
+    }
 
     /**
      * @return PostgresConnection


### PR DESCRIPTION
This PR allows the ability to set a column to `tsvector` which is a type for text searches.

See [tsvector docs](http://www.postgresql.org/docs/current/static/datatype-textsearch.html)