### PR TITLE
removes inherits table quotes

### DIFF
--- a/src/Bosnadev/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Bosnadev/Database/Schema/Grammars/PostgresGrammar.php
@@ -325,7 +325,7 @@ class PostgresGrammar extends \Illuminate\Database\Schema\Grammars\PostgresGramm
         $sql = parent::compileCreate($blueprint, $command);
 
         if (isset($blueprint->inherits)) {
-            $sql .= ' INHERITS ("'.$blueprint->inherits.'")';
+            $sql .= ' INHERITS ('.$blueprint->inherits.')';
         }
         return $sql;
     }


### PR DESCRIPTION
Without this fix, package would generate inherits query like `create table "regions" () INHERITS ("public.regions")`. That doesn't work because there's quotes around inherit table name