### PR TITLE
remove already created methods from Blueprint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   ],
   "require": {
-    "php": ">=5.4",
+    "php": ">=5.5",
     "illuminate/database": "^5.0",
     "ramsey/uuid": "^3.0",
     "doctrine/dbal": "^2.5"

--- a/src/Bosnadev/Database/Schema/Blueprint.php
+++ b/src/Bosnadev/Database/Schema/Blueprint.php
@@ -101,37 +101,6 @@ class Blueprint extends \Illuminate\Database\Schema\Blueprint
     }
 
     /**
-     * @param $column
-     * @return \Illuminate\Support\Fluent
-     */
-    public function uuid($column)
-    {
-        return $this->addColumn('uuid', $column);
-    }
-
-    /**
-     * Create a new jsonb column on the table
-     *
-     * @param $column
-     * @return \Illuminate\Support\Fluent
-     */
-    public function jsonb($column)
-    {
-        return $this->addColumn('jsonb', $column);
-    }
-
-    /**
-     * Create a new IPv4/IPv6 address (inet) column on the table.
-     *
-     * @param  string  $column
-     * @return \Illuminate\Support\Fluent
-     */
-    public function ipAddress($column)
-    {
-        return $this->addColumn('ipAddress', $column);
-    }
-    
-    /**
      * Create a new netmask (CIDR-notation) (cidr) column on the table.
      *
      * @param  string  $column
@@ -140,28 +109,6 @@ class Blueprint extends \Illuminate\Database\Schema\Blueprint
     public function netmask($column)
     {
         return $this->addColumn('netmask', $column);
-    }
-    
-    /**
-     * Create a new MAC address (macaddr) column on the table.
-     *
-     * @param  string  $column
-     * @return \Illuminate\Support\Fluent
-     */
-    public function macAddress($column)
-    {
-        return $this->addColumn('macAddress', $column);
-    }
-
-    /**
-     * Create a new point column on the table.
-     *
-     * @param  string  $column
-     * @return \Illuminate\Support\Fluent
-     */
-    public function point($column)
-    {
-        return $this->addColumn('point', $column);
     }
 
     /**
@@ -206,17 +153,6 @@ class Blueprint extends \Illuminate\Database\Schema\Blueprint
     public function box($column)
     {
         return $this->addColumn('box', $column);
-    }
-
-    /**
-     * Create a new polygon column on the table.
-     *
-     * @param  string  $column
-     * @return \Illuminate\Support\Fluent
-     */
-    public function polygon($column)
-    {
-        return $this->addColumn('polygon', $column);
     }
 
     /**


### PR DESCRIPTION
The goal is to remove overrides of existing methods of \Illuminate\Database\Schema\Blueprint
In laravel/framework 5.6.24, for example, the [point](https://github.com/laravel/framework/commit/ddc4e05fc03a8f55a56be2afdce48ba891879d65) method has changed its signature, thus when running laravel (with php 7.2) we get : 

ErrorException: Declaration of Bosnadev\Database\Schema\Blueprint::point($column) should be compatible with Illuminate\Database\Schema\Blueprint::point($column, $srid = NULL)

also upgraded php to 5.5: 
because you use ::class that has been added to use php 5.5 
(@see [http://php.net/manual/en/language.oop5.constants.php](http://php.net/manual/en/language.oop5.constants.php))