### PR TITLE
In laravel 7.x ramsey/uuid 4.0.1 is installed by default. To make it …

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "php": ">=5.5",
     "illuminate/database": "^5.0|^6.0|^7.0",
-    "ramsey/uuid": "^3.0",
+    "ramsey/uuid": "^3.0|^4.0",
     "doctrine/dbal": "^2.5"
   },
   "require-dev": {


### PR DESCRIPTION
…compatible with laravel 7.x the database library should work with ramsey/uuid 4.0.1 aswell