### PR TITLE
Add Laravel 8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Laravel Postgres Extended
 An extended PostgreSQL driver for Laravel 5.2+ with support for some aditional PostgreSQL data types: hstore, uuid, geometric types (point, path, circle, line, polygon...)
 
 ## Getting Started  
-### Laravel 5.2
+### Laravel 5.2+
 1. Run `composer require bosnadev/database` in your project root directory.
 2. Add `Bosnadev\Database\DatabaseServiceProvider::class` to `config/app.php`'s `providers` array.
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   ],
   "require": {
     "php": ">=5.5",
-    "illuminate/database": "^5.0|^6.0|^7.0",
+    "illuminate/database": "^5.0|^6.0|^7.0|^8.0",
     "ramsey/uuid": "^3.0|^4.0",
     "doctrine/dbal": "^2.5"
   },


### PR DESCRIPTION
Laravel 8 was released yesterday, this PR simply adds support for `illuminate/database ^8.0` in `composer.json`.