### PR TITLE
Handle column type methods using __call magic method

### DIFF
--- a/src/Bosnadev/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Bosnadev/Database/Schema/Grammars/PostgresGrammar.php
@@ -8,13 +8,20 @@ use Bosnadev\Database\Schema\Blueprint;
 
 /**
  * Class PostgresGrammar
+ *
+ * Available Column Type supported dynamically:
+ * hstore, uuid, jsonb, point, line,
+ * path, box, polygon, circle,
+ * money, int4range, int8range, numrange,
+ * tsrange, tstzrange, daterange, tsvector
+ *
  * @package Bosnadev\Database\Schema\Grammars
  */
 class PostgresGrammar extends \Illuminate\Database\Schema\Grammars\PostgresGrammar
 {
      /**
      * Check if the type is uuid, use internal guid
-     * 
+     *
      * @param  string $type
      * @return \Doctrine\DBAL\Types\Type
      */
@@ -25,6 +32,22 @@ class PostgresGrammar extends \Illuminate\Database\Schema\Grammars\PostgresGramm
         }
 
         return parent::getDoctrineColumnType($type);
+    }
+
+    /**
+     * Handle dynamic method calls.
+     *
+     * @param  string $method
+     * @param  array $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        if(substr($method, 0, 4) === 'type') {
+            $type = substr($method, 4, strlen($method) - 4);
+
+            return lcfirst($type);
+        }
     }
 
     /**
@@ -39,39 +62,6 @@ class PostgresGrammar extends \Illuminate\Database\Schema\Grammars\PostgresGramm
     }
 
     /**
-     * Create the column definition for a hstore type.
-     *
-     * @param Fluent $column
-     * @return string
-     */
-    protected function typeHstore(Fluent $column)
-    {
-        return "hstore";
-    }
-
-    /**
-     * Create the column definition for a uuid type.
-     *
-     * @param Fluent $column
-     * @return string
-     */
-    protected function typeUuid(Fluent $column)
-    {
-        return "uuid";
-    }
-
-    /**
-     * Create the column definition for a jsonb type.
-     *
-     * @param Fluent $column
-     * @return string
-     */
-    protected function typeJsonb(Fluent $column)
-    {
-        return "jsonb";
-    }
-
-    /**
      * Create the column definition for an IPv4 or IPv6 address.
      *
      * @param  \Illuminate\Support\Fluent  $column
@@ -81,6 +71,7 @@ class PostgresGrammar extends \Illuminate\Database\Schema\Grammars\PostgresGramm
     {
         return 'inet';
     }
+
     /**
      * Create the column definition for a CIDR notation-style netmask.
      *
@@ -104,28 +95,6 @@ class PostgresGrammar extends \Illuminate\Database\Schema\Grammars\PostgresGramm
     }
 
     /**
-     * Create the column definition for a 2D geometric point (x, y), x and y are floating-point numbers.
-     *
-     * @param  \Illuminate\Support\Fluent  $column
-     * @return string
-     */
-    protected function typePoint(Fluent $column)
-    {
-        return 'point';
-    }
-
-    /**
-     * Create the column definition for a line represented as a standard linear equation Ax + By + C = 0.
-     *
-     * @param  \Illuminate\Support\Fluent  $column
-     * @return string
-     */
-    protected function typeLine(Fluent $column)
-    {
-        return 'line';
-    }
-
-    /**
      * Create the column definition for a line segment represented by two points (x1, y1), (x2, y2).
      *
      * @param  \Illuminate\Support\Fluent  $column
@@ -134,148 +103,6 @@ class PostgresGrammar extends \Illuminate\Database\Schema\Grammars\PostgresGramm
     protected function typeLineSegment(Fluent $column)
     {
         return 'lseg';
-    }
-
-    /**
-     * Create the column definition for a path represented as a list of points (x1, y1), (x2, y2), ..., (xn, yn).
-     *
-     * @param  \Illuminate\Support\Fluent  $column
-     * @return string
-     */
-    protected function typePath(Fluent $column)
-    {
-        return 'path';
-    }
-
-    /**
-     * Create the column definition for a box represented by opposite corners of the box as points (x1, y1), (x2, y2).
-     *
-     * @param  \Illuminate\Support\Fluent  $column
-     * @return string
-     */
-    protected function typeBox(Fluent $column)
-    {
-        return 'box';
-    }
-
-    /**
-     * Create the column definition for a polygon represented by a list of points (vertices of the polygon).
-     *
-     * @param  \Illuminate\Support\Fluent  $column
-     * @return string
-     */
-    protected function typePolygon(Fluent $column)
-    {
-        return 'polygon';
-    }
-
-    /**
-     * Create the column definition for a circle represented by a center point and a radius <(x, y), r>
-     *
-     * @param  \Illuminate\Support\Fluent  $column
-     * @return string
-     */
-    protected function typeCircle(Fluent $column)
-    {
-        return 'circle';
-    }
-
-    /**
-     * Create the column definition for storing amounts of currency with a fixed fractional precision.
-     *
-     * This will store values in the range of: -92233720368547758.08 to +92233720368547758.07. (92 quadrillion).
-     * Output is locale-sensitive, see lc_monetary setting of PostgreSQL instance/s.
-     *
-     * @param  \Illuminate\Support\Fluent  $column
-     * @return string
-     */
-    protected function typeMoney(Fluent $column)
-    {
-        return 'money';
-    }
-
-    /**
-     * Create the column definition for an int4range type.
-     *
-     * @param Fluent $column
-     *
-     * @return string
-     */
-    protected function typeInt4range(Fluent $column)
-    {
-        return "int4range";
-    }
-
-    /**
-     * Create the column definition for an int8range type.
-     *
-     * @param Fluent $column
-     *
-     * @return string
-     */
-    protected function typeInt8range(Fluent $column)
-    {
-        return "int8range";
-    }
-
-    /**
-     * Create the column definition for an numrange type.
-     *
-     * @param Fluent $column
-     *
-     * @return string
-     */
-    protected function typeNumrange(Fluent $column)
-    {
-        return "numrange";
-    }
-
-    /**
-     * Create the column definition for an tsrange type.
-     *
-     * @param Fluent $column
-     *
-     * @return string
-     */
-    protected function typeTsrange(Fluent $column)
-    {
-        return "tsrange";
-    }
-
-    /**
-     * Create the column definition for an tstzrange type.
-     *
-     * @param Fluent $column
-     *
-     * @return string
-     */
-    protected function typeTstzrange(Fluent $column)
-    {
-        return "tstzrange";
-    }
-
-    /**
-     * Create the column definition for an daterange type.
-     *
-     * @param Fluent $column
-     *
-     * @return string
-     */
-    protected function typeDaterange(Fluent $column)
-    {
-        return "daterange";
-    }
-    
-    /**
-     * Create the column definition for a Text Search Vector type.
-     *
-     * @param Fluent $column
-     *
-     * @return string
-     */
-    protected function typeTsvector(Fluent $column)
-    {
-        return "tsvector";
     }
 
     /**

--- a/src/Bosnadev/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Bosnadev/Database/Schema/Grammars/PostgresGrammar.php
@@ -43,10 +43,12 @@ class PostgresGrammar extends \Illuminate\Database\Schema\Grammars\PostgresGramm
      */
     public function __call($method, $parameters)
     {
+        $method = strtolower($method);
+
         if(substr($method, 0, 4) === 'type') {
             $type = substr($method, 4, strlen($method) - 4);
 
-            return lcfirst($type);
+            return $type;
         }
     }
 
@@ -140,7 +142,7 @@ class PostgresGrammar extends \Illuminate\Database\Schema\Grammars\PostgresGramm
 
         return sprintf('CREATE INDEX %s ON %s USING GIN(%s)', $command->index, $this->wrapTable($blueprint), $columns);
     }
-    
+
     /**
      * Compile a gist index key command.
      *


### PR DESCRIPTION
This PR removes MOST of the column type methods and handle them using `__call` method.
It will support the probably missing types.

And it reduced files size from 8360 to 4415 (`46%` lower) and line count from 348 to 175 (`49%` lower). 