### PR TITLE
Add Laravel 9 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   ],
   "require": {
     "php": ">=5.5",
-    "illuminate/database": "^5.0|^6.0|^7.0|^8.0",
+    "illuminate/database": "^5.0|^6.0|^7.0|^8.0|^9.0",
     "ramsey/uuid": "^3.0|^4.0",
     "doctrine/dbal": "^2.5|^3.0"
   },


### PR DESCRIPTION
Laravel 9 [is due](https://laravel.com/docs/8.x/releases#support-policy) for release on February 8th.

I've had a look through the [upgrade guide](https://laravel.com/docs/master/upgrade) _(in its current state - obviously won't be finalised until the release)_ and I don't think there are any breaking changes that will cause problems in this package.

Therefore this PR simply adds support for `illuminate/database ^9.0` in `composer.json`.