### PR TITLE
Laravel 10 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   ],
   "require": {
     "php": ">=5.5",
-    "illuminate/database": "^5.0|^6.0|^7.0|^8.0|^9.0",
+    "illuminate/database": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0",
     "ramsey/uuid": "^3.0|^4.0",
     "doctrine/dbal": "^2.5|^3.0"
   },


### PR DESCRIPTION
Hello there. I need this package to be able to use with Laravel 10. 

It's a dependency of https://github.com/mstaack/laravel-postgis and it looks like I'm blocked with upgrading to Laravel 10 because of `"illuminate/database": "^5.0|^6.0|^7.0|^8.0|^9.0"` restriction.